### PR TITLE
Add match to json results

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -18,7 +18,7 @@ const jsonLogger = new JSONLogger({objectMode: true, highWaterMark: 4});
  */
 const searchMarkup = (searchString, fileExtension = 'html') => {
   return new Promise((resolve, reject) => {
-    const grep = spawn('grep', ['-nrliF', `--include=*\.${fileExtension}`, searchString, 'target']);
+    const grep = spawn('grep', ['-nriF', `--include=*\.${fileExtension}`, searchString, 'target']);
 
     grep.stdout
       .pipe(lineByLine)

--- a/lib/streams/ServiceResults.js
+++ b/lib/streams/ServiceResults.js
@@ -3,6 +3,17 @@ import {sep as pathSeparator} from 'path';
 
 /**
  * Create service result object, populate with info and results then provide to consumer stream when complete
+ * Example Service Results object:
+ {
+  "name": "service-name",
+  "github": "",
+  "count": 1,
+  "files": [{
+    path: "",
+    line: "",
+    match: ""
+  }]
+ }
  */
 class ServiceResults extends Transform {
   constructor(options) {
@@ -20,7 +31,8 @@ class ServiceResults extends Transform {
   }
 
   _transform(line, encoding, done) {
-    const [, folder, ...filePathParts] = line.split(pathSeparator);
+    const [filePathDetail, lineNumber, matchString] = line.split(':');
+    const [, folder, ...filePathParts] = filePathDetail.split(pathSeparator);
     const filePath = pathSeparator + filePathParts.join(pathSeparator);
     const repoNameParts = folder.split('-');
     const whichGithub = repoNameParts.splice((repoNameParts.length -1), 1)[0];
@@ -34,7 +46,11 @@ class ServiceResults extends Transform {
     this.serviceResults.name = repoName;
     this.serviceResults.github = whichGithub;
     this.serviceResults.count++;
-    this.serviceResults.files.push(filePath);
+    this.serviceResults.files.push({
+      path: filePath,
+      line: lineNumber,
+      match: matchString.trim()
+    });
 
     done();
   }

--- a/test/JSONLogger.test.js
+++ b/test/JSONLogger.test.js
@@ -9,9 +9,21 @@ const serviceResults = [
     github: 'public',
     count: 3,
     files: [
-      '/example/file/path/file.html',
-      '/example/file/path/file1.html',
-      '/example/file/path/file2.html'
+      {
+        'path': '/example/file/path/file.html',
+        'line': '19',
+        'match': 'example match'
+      },
+      {
+        'path': '/example/file/path/file1.html',
+        'line': '34',
+        'match': 'other example match'
+      },
+      {
+        'path': '/example/file/path/file2.html',
+        'line': '101',
+        'match': 'another example match'
+      }
     ]
   },
   {
@@ -19,8 +31,16 @@ const serviceResults = [
     github: 'public',
     count: 2,
     files: [
-      '/example/file/path/file-other.html',
-      '/example/file/path/file-other1.html'
+      {
+        'path': '/example/file/path/file-other.html',
+        'line': '1',
+        'match': 'other match'
+      },
+      {
+        'path': '/example/file/path/file-other1.html',
+        'line': '3',
+        'match': 'another other match'
+      }
     ]
   }
 ];

--- a/test/ServiceResults.test.js
+++ b/test/ServiceResults.test.js
@@ -5,11 +5,11 @@ import {PassThrough} from 'stream';
 const passThrough = new PassThrough({objectMode: true});
 const serviceResults = new ServiceResults({objectMode: true});
 const inputLines = [
-  'target/service-name-public/example/file/path/file.html',
-  'target/service-name-public/example/file/path/file1.html',
-  'target/service-name-public/example/file/path/file2.html',
-  'target/service-name-other-public/example/file/path/file-other.html',
-  'target/service-name-other-public/example/file/path/file-other1.html'
+  'target/service-name-public/example/file/path/file.html:19: example match',
+  'target/service-name-public/example/file/path/file1.html:34: other example match',
+  'target/service-name-public/example/file/path/file2.html:101: another example match',
+  'target/service-name-other-public/example/file/path/file-other.html:1: other match',
+  'target/service-name-other-public/example/file/path/file-other1.html:3: another other match'
 ];
 const expectedServiceResults = [
   {
@@ -17,9 +17,21 @@ const expectedServiceResults = [
     github: 'public',
     count: 3,
     files: [
-      '/example/file/path/file.html',
-      '/example/file/path/file1.html',
-      '/example/file/path/file2.html'
+      {
+        'path': '/example/file/path/file.html',
+        'line': '19',
+        'match': 'example match'
+      },
+      {
+        'path': '/example/file/path/file1.html',
+        'line': '34',
+        'match': 'other example match'
+      },
+      {
+        'path': '/example/file/path/file2.html',
+        'line': '101',
+        'match': 'another example match'
+      }
     ]
   },
   {
@@ -27,8 +39,16 @@ const expectedServiceResults = [
     github: 'public',
     count: 2,
     files: [
-      '/example/file/path/file-other.html',
-      '/example/file/path/file-other1.html'
+      {
+        'path': '/example/file/path/file-other.html',
+        'line': '1',
+        'match': 'other match'
+      },
+      {
+        'path': '/example/file/path/file-other1.html',
+        'line': '3',
+        'match': 'another other match'
+      }
     ]
   }
 ];


### PR DESCRIPTION
Record the match found by grep in the `results.json` file.

A by product of removing the `-l` flag on grep to expose the match is we now get all matches in a file. Previously using `-l` we just got the first match in a file. IMO it feels like we do want all matches.


### Example JSON output
**Search term**: `node index.js 'global-breadcrumb'`
**Result**:
```
[
  {
    "name": "<repo>-frontend",
    "github": "<which-github>",
    "count": 1,
    "files": [
      {
        "path": "<file-path>.html",
        "line": "3",
        "match": "<div id=\"global-breadcrumb\" class=\"global-breadcrumb--no-border\">"
      }
    ]
  },
  {
    "name": "<repo>-frontend",
    "github": "<which-github>",
    "count": 1,
    "files": [
      {
        "path": "<file-path>.html",
        "line": "19",
        "match": "<div class=\"header-context toolbar\" id=\"global-breadcrumb\">"
      }
    ]
  }
]
```