### PR TITLE
Add test to ensure config.sample.json exists

### DIFF
--- a/test/config.sample.test.js
+++ b/test/config.sample.test.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+import test from 'ava';
+
+const configSample = path.resolve('..', 'config.sample.json');
+
+test.cb('config.sample.json should exist', t => {
+  fs.stat(configSample, (err, stats) => {
+    let isFile = stats && stats.isFile();
+    t.true(isFile, 'config.sample.json does not exist');
+    t.end();
+  });
+});


### PR DESCRIPTION
This test guards against people renaming `config.sample.json` during setup and committing the deletion (as git would see it).