### PR TITLE
Add ability to choose file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A tool to search repositories for a string.
 $ node index.js foo
 # or
 $ component-finder foo
+# or
+$ ./cf foo
 ```
 
 
@@ -73,6 +75,8 @@ Duplicate the `config.sample.json` file, naming it `config.json`, and update its
 $ node index.js searchString
 # or
 $ component-finder searchString
+# or
+$ ./cf searchString
 ```
 Where `searchString`...
 
@@ -107,7 +111,29 @@ Input is cleaned up before a search is performed. The following characters are r
 * `[disabled]` (attribute selectors)
 * `   ` (extraneous whitespace)
 
-#### Results
+### Advanced Options
+
+#### Search string
+
+Component Finder will take the third string on the command line as the searchString to look for **by default**.
+
+e.g. `node index.js search-for-third-argument`
+
+Or the `-s` option can be specifically used to signal the subsequent string as the searchString - this can be useful when passing other command line flags and mixing the order of arguments.
+
+For example, when used with the File Extension flag discussed below the following command will search for *"snippet"* in Markdown files :
+
+`node index.js -f md -s snippet` 
+
+#### File Extensions
+
+By default, component finder searches through html files. You can modify or expand the search to include other file types with the `-f` flag and including a comma separated list of file extensions. This list should not include 'dot's or spaces. If it does include spaces, it should be enclosed in quotes :
+
+e.g. `node index.js searchstring -f html,scala`
+
+e.g. `node index.js searchstring -f jade`
+
+### Results
 
 Results appear in the console like this...
 

--- a/cf
+++ b/cf
@@ -1,0 +1,3 @@
+#!/bin/bash
+node index.js "$@"
+

--- a/finder.js
+++ b/finder.js
@@ -4,20 +4,26 @@ import search from './lib/search';
 import sanitizer from './lib/utils/sanitizer';
 import serviceCatalogue from './lib/serviceCatalogue';
 import isFrontendService from './lib/utils/isFrontendService';
+import parseOptions from './lib/utils/parseOptions';
 
 try {
   var config = require('./config.json');
 }
 catch(err) {
-  process.stdout.write(`${EOL}No config.json file found.${EOL}Please see README.md for details.${EOL}`);
-  process.exit();
+  process.stdout.write(`${EOL}No config.json file found.${EOL}Please see README.md for details.${EOL}${EOL}`);
+  process.exit(1);
 };
 
-const searchString = process.argv[2];
-const sanitisedSearchString = sanitizer(searchString);
+const searchOptions = parseOptions(process.argv.slice());
+if (searchOptions.optionErrors.length) {
+  searchOptions.optionErrors.forEach(msg => {
+    process.stdout.write(msg);
+  });
+  process.exit(1);
+}
 
 serviceCatalogue.getProjects(config.api)
   .then(services => services.filter(service => isFrontendService(service.name, config.whitelist)))
   .then(frontendServices => clone(frontendServices))
-  .then(() => search(sanitisedSearchString))
+  .then(() => search(searchOptions))
   .catch(err => console.error(err));

--- a/lib/search.js
+++ b/lib/search.js
@@ -10,14 +10,13 @@ const jsonLogger = new JSONLogger({objectMode: true});
 
 /**
  * Search html markup using grep
- * @param searchString
- * @param pattern
+ * @param {searchOptions}
  * @returns {Promise}
  */
-const searchMarkup = (searchString, fileExtension = 'html') => {
+const searchMarkup = (searchOptions) => {
   // forward slash is made windows compatible inside glob https://www.npmjs.com/package/glob#windows
-  const findFiles = new FindFiles({objectMode: true}, `target/**/*.${fileExtension}`);
-  const match = new Match({objectMode: true}, searchString);
+  const findFiles = new FindFiles({objectMode: true}, `target/**/*.${searchOptions.fileExtensions}`);
+  const match = new Match({objectMode: true}, searchOptions);
 
   findFiles
     .pipe(match)

--- a/lib/streams/FindFiles.js
+++ b/lib/streams/FindFiles.js
@@ -10,7 +10,9 @@ class FindFiles extends Readable {
 
   _read() {
     const files = glob.sync(this.filePathPattern, {
-      ignore: '**/node_modules/**'
+      ignore: [
+        '**/node_modules/**'
+      ]
     });
 
     files.forEach((file) => this.push(file));

--- a/lib/streams/Match.js
+++ b/lib/streams/Match.js
@@ -12,9 +12,9 @@ import {EOL as newline} from 'os';
  }
  */
 class Match extends Transform {
-  constructor(options, searchString) {
+  constructor(options, searchOptions) {
     super(options);
-    this.searchString = searchString;
+    this.searchString = searchOptions.searchString;
   }
 
   _transform(filePath, encoding, done) {

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -1,0 +1,14 @@
+import {EOL} from 'os';
+
+module.exports = {
+  CONSTANTS: {
+    FILE_EXTENSION_DEFAULT: 'html'
+  },
+  ERRORS: {
+    NO_SEARCH_STRING: `${EOL}MUST pass a search string as the FIRST option to Component Finder.${EOL}${EOL}`,
+    NO_FILE_EXTENSION: `${EOL}No File Extensions Specified with "-f" option. ` +
+                         'Pass a comma separated list. ' +
+                         `(Omit spaces or enclose in quotes)${EOL}` +
+                         `e.g. "./cf <SEARCH_STRING> -f html,scala"${EOL}${EOL}`
+  }
+};

--- a/lib/utils/parseOptions.js
+++ b/lib/utils/parseOptions.js
@@ -1,0 +1,76 @@
+import minimist from 'minimist';
+import {EOL} from 'os';
+
+import sanitizer from './sanitizer';
+import {CONSTANTS, ERRORS} from './constants';
+
+function parseSearchString (argv, defaultSearch = '') {
+  const searchErrors = [];
+  let searchString = argv['s'] || defaultSearch;
+
+  if (searchString && typeof(searchString) === 'string') {
+    searchString = sanitizer(searchString);
+  } else {
+    searchErrors.push(ERRORS.NO_SEARCH_STRING);
+  }
+
+  return {
+    searchString,
+    searchErrors
+  }
+}
+
+function parseFileExtensions (argv) {
+  const extensionErrors = [];
+  let fileExtensions = CONSTANTS.FILE_EXTENSION_DEFAULT;
+  let extensionError    = false;
+
+  const passedExtensions = argv['f']
+                       || argv['file']
+                       || argv['files'];
+  if (passedExtensions) {
+    if (typeof(passedExtensions) === 'string') {
+      fileExtensions = passedExtensions.replace(/[\.\s]/g, '')
+                                       .split(',')
+                                       .filter(extension => !!extension); // filter empty strings
+      switch(fileExtensions.length) {
+        case 0:
+          extensionError = true;
+          break;
+        case 1:
+          fileExtensions = fileExtensions[0];
+          break;
+        default:
+          fileExtensions = '{' + fileExtensions.join(',') + '}';
+      }
+    } else {
+      extensionError = true;
+    }
+  }
+
+  if (extensionError) {
+    extensionErrors.push(ERRORS.NO_FILE_EXTENSION);
+  }
+
+  return {
+    fileExtensions,
+    extensionErrors
+  }
+}
+
+module.exports = args => {
+  const argv = minimist(args.slice(2));
+  const optionErrors = [];
+
+  const {searchString, searchErrors} = parseSearchString(argv, args[2]);
+  optionErrors.push(...searchErrors);
+
+  const {fileExtensions, extensionErrors} = parseFileExtensions(argv);
+  optionErrors.push(...extensionErrors);
+
+  return {
+    searchString,
+    fileExtensions,
+    optionErrors
+  };
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-register": "^6.11.6",
     "co": "^4.6.0",
     "glob": "^7.1.1",
+    "minimist": "^1.2.0",
     "progress": "^1.1.8"
   },
   "devDependencies": {

--- a/test/Match.test.js
+++ b/test/Match.test.js
@@ -20,9 +20,11 @@ const fsStub = sinon.stub(fs, 'readFileSync', () => {
 test.after('cleanup', t => fsStub.restore());
 
 test('searchString match should return correct details', async t => {
-
   const searchString = 'test3';
-  const match = new Match({objectMode: true}, searchString);
+  const searchOptions = {
+    searchString
+  };
+  const match = new Match({objectMode: true}, searchOptions);
   const passThrough = new PassThrough({objectMode: true});
   const expectedResult = {
     filePath: path,
@@ -39,9 +41,11 @@ test('searchString match should return correct details', async t => {
 });
 
 test('multiple searchString matches should return correct details', async t => {
-
   const searchString = 'test4';
-  const match = new Match({objectMode: true}, searchString);
+  const searchOptions = {
+    searchString
+  };
+  const match = new Match({objectMode: true}, searchOptions);
   const passThrough = new PassThrough({objectMode: true});
   const expectedResults = [
     {

--- a/test/parseOptions.test.js
+++ b/test/parseOptions.test.js
@@ -1,0 +1,85 @@
+import test from 'ava';
+import {EOL} from 'os';
+
+import parseOptions from './../lib/utils/parseOptions';
+import {ERRORS} from './../lib/utils/constants';
+
+const argArray = [
+  'path/to/node',
+  'path/to/js'
+];
+
+test('returns error if no search string passed', t => {
+  const searchOptions = parseOptions(argArray.slice());
+
+  t.deepEqual(searchOptions.optionErrors, [ERRORS.NO_SEARCH_STRING]);
+});
+
+test('returns error if no search string passed with -s option', t => {
+  const testArray = [...argArray, '-s'];
+  const searchOptions = parseOptions(testArray.slice());
+
+  t.deepEqual(searchOptions.optionErrors, [ERRORS.NO_SEARCH_STRING]);
+});
+
+test('returns correct default options for search string as default third argument', t => {
+  const testArray = [...argArray, 'SEARCH_STRING'];
+  const searchOptions = parseOptions(testArray.slice());
+  const expectedOptions = {
+    searchString: 'SEARCH_STRING',
+    fileExtensions: 'html',
+    optionErrors: []
+  };
+
+  t.deepEqual(searchOptions, expectedOptions);
+});
+
+test('returns error if no file extension specified with -f option', t => {
+  const testArray = [...argArray, 'SEARCH_STRING', '-f'];
+  const searchOptions = parseOptions(testArray);
+
+  t.deepEqual(searchOptions.optionErrors, [ERRORS.NO_FILE_EXTENSION]);
+});
+
+test('returns error if no file extension resolved with -f option', t => {
+  const testArray = [...argArray, 'SEARCH_STRING', '-f', ' . ,. '];
+  const searchOptions = parseOptions(testArray);
+
+  t.deepEqual(searchOptions.optionErrors, [ERRORS.NO_FILE_EXTENSION]);
+});
+
+test('returns correct options for single specified file extensions', t => {
+  const testArray = [...argArray, 'SEARCH_STRING', '-f', 'scala'];
+  const searchOptions = parseOptions(testArray);
+  const expectedOptions = {
+    searchString: 'SEARCH_STRING',
+    fileExtensions: 'scala',
+    optionErrors: []
+  };
+
+  t.deepEqual(searchOptions, expectedOptions);
+});
+
+test('returns correct options object for multiple file extensions', t => {
+  const testArray = [...argArray, 'SEARCH_STRING', '--file', 'html,scala'];
+  const searchOptions = parseOptions(testArray);
+  const expectedOptions = {
+    searchString: 'SEARCH_STRING',
+    fileExtensions: '{html,scala}',
+    optionErrors: []
+  };
+
+  t.deepEqual(searchOptions, expectedOptions);
+});
+
+test('returns correct options object for multiple specified options', t => {
+  const testArray = [...argArray, '--file', 'md', '-s', 'SEARCH_STRING'];
+  const searchOptions = parseOptions(testArray);
+  const expectedOptions = {
+    searchString: 'SEARCH_STRING',
+    fileExtensions: 'md',
+    optionErrors: []
+  };
+
+  t.deepEqual(searchOptions, expectedOptions);
+});


### PR DESCRIPTION
Issue https://github.com/hmrc/component-finder/issues/16

- add command line options parsing
- add `-f` option to specify file extensions to search
- add `-s` option to manually specify searchString (searchString defaults to third argument otherwise)
- add tests
- added a `.\cf` shortcut command 

### Advanced Options

#### Search string

Component Finder will take the third string on the command line as the searchString to look for **by default**.

e.g. `node index.js search-for-third-argument`

Or the `-s` option can be specifically used to signal the subsequent string as the searchString - this can be useful when passing other command line flags and mixing the order of arguments.

For example, when used with the File Extension flag discussed below the following command will search for *"snippet"* in Markdown files :

`node index.js -f md -s snippet` 

#### File Extensions

By default, component finder searches through html files. You can modify or expand the search to include other file types with the `-f` flag and including a comma separated list of file extensions. This list should not include 'dot's or spaces. If it does include spaces, it should be enclosed in quotes :

e.g. `node index.js searchstring -f html,scala`

e.g. `node index.js searchstring -f jade`
