### PR TITLE
Bad JSON error message differs

### DIFF
--- a/test/serviceCatalogue.test.js
+++ b/test/serviceCatalogue.test.js
@@ -111,7 +111,7 @@ test('.getServices() should reject when bad JSON is returned', t => {
   return serviceCatalogue.getServices(apiConfig, servicesAPIPath)
     .catch(err => {
       t.is(err.name, 'SyntaxError');
-      t.is(err.message, 'Unexpected token b');
+      t.true(err.message.includes('Unexpected token b'));
     });
 });
 


### PR DESCRIPTION
### Problem
I am getting `Unexpected token b in JSON at position 0` rather than the expected `Unexpected token b` for a bad `JSON` error. I suspect this is related to node version.

### Solution
Change the test to use a `.regex`