### PR TITLE
Update to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
   "presets": [
-    "es2015-node4"
+    [
+      "env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ]
   ]
 }

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 require('babel-register')
+require('babel-polyfill')
 require('./finder')

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "babel-preset-es2015-node4": "^2.1.0",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-env": "^1.2.1",
     "babel-register": "^6.11.6",
     "co": "^4.6.0",
     "glob": "^7.1.1",
@@ -43,7 +44,8 @@
   },
   "ava": {
     "require": [
-      "babel-register"
+      "babel-register",
+      "babel-polyfill"
     ]
   },
   "nyc": {
@@ -52,7 +54,8 @@
       "finder.js"
     ],
     "require": [
-      "babel-register"
+      "babel-register",
+      "babel-polyfill"
     ]
   }
 }


### PR DESCRIPTION
# Problem

Getting the following deprecated notice when running `npm install`:

```
npm WARN deprecated babel-preset-es2015-node4@2.1.1: Use npmjs.org/babel-preset-env instead, see https://github.com/babel/babel-preset-env
```

# Solution

Switch from `babel-preset-es2015-node4` to [`babel-preset-env`](https://github.com/babel/babel-preset-env)

Because we're using `co` we also have to require [`babel-polyfill`](https://babeljs.io/docs/usage/polyfill/) to cover transforms.

We could drop all these deps (including `babel` itself) by only supporting node `>=6` but that's a separate conversation.