### PR TITLE
chunk spawn process

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,9 +1,12 @@
 import co from 'co'
 import path from 'path'
 import Progress from 'progress'
-import {EOL as newline} from 'os'
+import {EOL as newline, cpus} from 'os'
 import {spawn} from 'child_process'
 import toSshGitHubUrl from './utils/toSshGitHubUrl'
+import chunkArray from './utils/chunkArray'
+
+const numberOfCPUs = cpus().length
 
 /**
  * get an array containing all Service GitHub details
@@ -49,21 +52,24 @@ const cloneTask = (sshGitHubUrl, repoName, progressBar) => {
 const clone = (services, task = cloneTask) => {
   process.stdout.write(`Cloning repos...${newline}`)
 
-  const gitHubDetails = getGitHubDetails(services)
+  const gitHubRepoInfo = getGitHubDetails(services)
   const progressBar = new Progress(':percent [:bar] (:current/:total)', {
-    total: gitHubDetails.length,
+    total: gitHubRepoInfo.length,
     clear: true
   })
+  const githubInfoParentArray = chunkArray(gitHubRepoInfo, numberOfCPUs * 4)
 
-  return co(function *() {
-    return yield gitHubDetails.map(githubDetail => {
-      const url = githubDetail.url
-      const whichGitHub = githubDetail.name === 'github-com' ? 'public' : 'enterprise'
-      const repoName = `${url.split('/').pop()}-${whichGitHub}`
-      const sshGitHubUrl = toSshGitHubUrl(url)
+  return co(function * () {
+    for (let i = 0; i < githubInfoParentArray.length; i++) {
+      yield githubInfoParentArray[i].map((details) => {
+        const url = details.url
+        const whichGitHub = details.name === 'github-com' ? 'public' : 'enterprise'
+        const repoName = `${url.split('/').pop()}-${whichGitHub}`
+        const sshGitHubUrl = toSshGitHubUrl(url)
 
-      return task(sshGitHubUrl, repoName, progressBar)
-    })
+        return task(sshGitHubUrl, repoName, progressBar)
+      })
+    }
   })
 }
 

--- a/lib/utils/chunkArray.js
+++ b/lib/utils/chunkArray.js
@@ -1,0 +1,11 @@
+const chunkArray = (array, size) => {
+  const chunkedArrays = []
+
+  for (let i = 0; i < array.length; i += size) {
+    chunkedArrays.push(array.slice(i, i + size))
+  }
+
+  return chunkedArrays
+}
+
+export default chunkArray

--- a/test/chunkArray.test.js
+++ b/test/chunkArray.test.js
@@ -1,0 +1,19 @@
+import test from 'ava'
+import chunkArray from './../lib/utils/chunkArray'
+
+test('.chunkArray() should chunk an array as expected', t => {
+  t.plan(3)
+
+  const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  const chunkedArray = chunkArray(array, 3)
+  const expectedChunkedArray = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+    [10]
+  ]
+
+  t.true(chunkedArray instanceof Array)
+  t.is(chunkedArray.length, 4)
+  t.deepEqual(chunkedArray, expectedChunkedArray)
+})


### PR DESCRIPTION
## Problem
@ian-leggett was having issues on his machine due to ~190 spawn child processes firing off!

## Solution
This work chunks the promise array into manageable chunks for `co` to `yield`, so only the number of CPU's your machine has x 4 `spawn` processes are fired off and `yielded` at a time.

### Of Note
- I have chunked the promise array into arrays of length `(number of CPUs x 4)` this works well on @ian-leggett machine and feels like a sensible size 
- I have used a `for` loop inside of `co` due to `.forEach` causing an error with the reserved word `yield` inside of `co`. 