### PR TITLE
add full match url to results

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -5,5 +5,9 @@
     "paths": [],
     "headers": {}
   },
-  "whitelist": []
+  "whitelist": [],
+  "repositories" : {
+    "open": "",
+    "private": ""
+  }
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -4,8 +4,9 @@ import FindFiles from './streams/FindFiles'
 import ServiceResults from './streams/ServiceResults'
 import ConsoleLogger from './streams/ConsoleLogger'
 import JSONLogger from './streams/JSONLogger'
+import config from './../config.json'
 
-const createServiceResults = new ServiceResults({objectMode: true})
+const createServiceResults = new ServiceResults({objectMode: true}, config.repositories)
 const consoleLogger = new ConsoleLogger({objectMode: true})
 const jsonLogger = new JSONLogger({objectMode: true})
 

--- a/lib/streams/ServiceResults.js
+++ b/lib/streams/ServiceResults.js
@@ -9,6 +9,7 @@ import {sep as pathSeparator} from 'path'
   "github": "",
   "count": 1,
   "files": [{
+    url: "",
     path: "",
     line: "",
     match: ""
@@ -16,8 +17,9 @@ import {sep as pathSeparator} from 'path'
  }
  */
 class ServiceResults extends Transform {
-  constructor (options) {
+  constructor (options, repositories) {
     super(options)
+    this.repositories = repositories
     this.createServiceResultsObj()
   }
 
@@ -30,6 +32,20 @@ class ServiceResults extends Transform {
     }
   }
 
+  buildMatchUrl (whichGithub, repoName, filePath, lineNumber) {
+    return [
+      'https://',
+      whichGithub === 'enterprise'
+        ? this.repositories.private
+        : this.repositories.open,
+      '/hmrc/',
+      repoName,
+      '/blob/master',
+      filePath,
+      `#L${lineNumber}`
+    ].join('')
+  }
+
   _transform (matchDetail, encoding, done) {
     // filePath (a result from glob) has forward slashes for all platforms https://www.npmjs.com/package/glob#windows
     const [, folder, ...filePathParts] = matchDetail.filePath.split('/')
@@ -37,6 +53,7 @@ class ServiceResults extends Transform {
     const repoNameParts = folder.split('-')
     const whichGithub = repoNameParts.splice((repoNameParts.length - 1), 1)[0]
     const repoName = repoNameParts.join('-')
+    const url = this.buildMatchUrl(whichGithub, repoName, filePath, matchDetail.lineNumber)
 
     if (this.serviceResults.name && this.serviceResults.name !== repoName) {
       this.push(this.serviceResults)
@@ -47,6 +64,7 @@ class ServiceResults extends Transform {
     this.serviceResults.github = whichGithub
     this.serviceResults.count++
     this.serviceResults.files.push({
+      url: url,
       path: filePath,
       line: matchDetail.lineNumber,
       match: matchDetail.match.trim()

--- a/test/ServiceResults.test.js
+++ b/test/ServiceResults.test.js
@@ -3,7 +3,10 @@ import ServiceResults from './../lib/streams/ServiceResults'
 import {PassThrough} from 'stream'
 
 const passThrough = new PassThrough({objectMode: true})
-const serviceResults = new ServiceResults({objectMode: true})
+const serviceResults = new ServiceResults({objectMode: true}, {
+  open: 'example.open.com',
+  private: 'example.private.com'
+})
 const matchDetailInputs = [
   {
     filePath: 'target/service-name-public/example/file/path/file.html',
@@ -21,12 +24,12 @@ const matchDetailInputs = [
     match: 'another example match'
   },
   {
-    filePath: 'target/service-name-other-public/example/file/path/file-other.html',
+    filePath: 'target/service-name-other-enterprise/example/file/path/file-other.html',
     lineNumber: 1,
     match: 'other match'
   },
   {
-    filePath: 'target/service-name-other-public/example/file/path/file-other1.html',
+    filePath: 'target/service-name-other-enterprise/example/file/path/file-other1.html',
     lineNumber: 3,
     match: 'another other match'
   }
@@ -39,16 +42,19 @@ const expectedServiceResults = [
     count: 3,
     files: [
       {
+        'url': 'https://example.open.com/hmrc/service-name/blob/master/example/file/path/file.html#L19',
         'path': '/example/file/path/file.html',
         'line': 19,
         'match': 'example match'
       },
       {
+        'url': 'https://example.open.com/hmrc/service-name/blob/master/example/file/path/file1.html#L34',
         'path': '/example/file/path/file1.html',
         'line': 34,
         'match': 'other example match'
       },
       {
+        'url': 'https://example.open.com/hmrc/service-name/blob/master/example/file/path/file2.html#L101',
         'path': '/example/file/path/file2.html',
         'line': 101,
         'match': 'another example match'
@@ -57,15 +63,17 @@ const expectedServiceResults = [
   },
   {
     name: 'service-name-other',
-    github: 'public',
+    github: 'enterprise',
     count: 2,
     files: [
       {
+        'url': 'https://example.private.com/hmrc/service-name-other/blob/master/example/file/path/file-other.html#L1',
         'path': '/example/file/path/file-other.html',
         'line': 1,
         'match': 'other match'
       },
       {
+        'url': 'https://example.private.com/hmrc/service-name-other/blob/master/example/file/path/file-other1.html#L3',
         'path': '/example/file/path/file-other1.html',
         'line': 3,
         'match': 'another other match'
@@ -77,7 +85,7 @@ const expectedServiceResults = [
 test('service results created from lined input should be provided to consumer', async t => {
   let count = 0
 
-  matchDetailInputs.forEach(matchDetail => passThrough.write(matchDetail))
+  matchDetailInputs.forEach((matchDetail) => passThrough.write(matchDetail))
   passThrough.end()
 
   await passThrough


### PR DESCRIPTION
## Problem
You have to construct the match url if you wish to have a look at the match in a browser. 

## Solution
We have all the parts to create the url, this work brings them together and adds them to the `results.json` file. This work fixes #28 

### Of Note
I have added the hosts for open and private to the config file. Please update your config if you are running this branch. I will update the config in the relevant place once it has been merged.

## Screenshot
![screen shot 2017-03-17 at 15 38 12](https://cloud.githubusercontent.com/assets/2305016/24052057/0f85391c-0b2c-11e7-8d7a-13b60bad31d0.png)


