### PR TITLE
add full match url to results

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ They are also saved to a `results.json` file like this...
   "github": "",
   "count": 1,
   "files": [{
+    url: "",
     path: "",
     line: "",
     match: ""
@@ -149,6 +150,7 @@ They are also saved to a `results.json` file like this...
 
 * **name**: The name of the repository
 * **github**: Whether the repository lives in the open or in an enterprise instance of github
+* **files.url**: The GitHub url to the file and line that contains the match
 * **files.path**: The path to a file that contains `searchString`
 * **files.line**: The line in the file where the match occurs
 * **files.match**: The actual match that was found in the file

--- a/finder.js
+++ b/finder.js
@@ -4,13 +4,14 @@ import clone from './lib/clone'
 import search from './lib/search'
 import serviceCatalogue from './lib/serviceCatalogue'
 import isFrontendService from './lib/utils/isFrontendService'
+import getServiceRepoDetails from './lib/utils/serviceRepoDetails'
 
 try {
   var config = require('./config.json')
 } catch (err) {
   process.stdout.write(`${EOL}No config.json file found.${EOL}Please see README.md for details.${EOL}${EOL}`)
   process.exit(1)
-};
+}
 
 const args = yargs
   .usage('node $0 [options] search_string')
@@ -25,10 +26,11 @@ const args = yargs
   .argv
 
 serviceCatalogue.getProjects(config.api)
-  .then(services => services.filter(service => isFrontendService(service.name, config.whitelist)))
-  .then(frontendServices => clone(frontendServices))
-  .then(() => search({
-    fileExtensions: args.file,
-    searchString: args._
-  }))
-  .catch(err => console.error(err))
+  .then((services) => services.filter(service => isFrontendService(service.name, config.whitelist)))
+  .then((frontendServices) => {
+    const serviceRepoDetails = getServiceRepoDetails(frontendServices)
+
+    return clone(serviceRepoDetails.details)
+      .then(() => search(serviceRepoDetails.urls, {fileExtensions: args.file, searchString: args._}))
+  })
+  .catch((err) => console.error(err))

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -9,17 +9,6 @@ import chunkArray from './utils/chunkArray'
 const numberOfCPUs = cpus().length
 
 /**
- * get an array containing all Service GitHub details
- * @param services
- * @returns {Array[Object{name, displayName, url}]}
- */
-const getGitHubDetails = services => {
-  return services
-    .map(service => service.githubUrls)
-    .reduce((prev, curr) => prev.concat(curr))
-}
-
-/**
  *
  * @param resolve
  * @param reject
@@ -49,21 +38,20 @@ const cloneTask = (sshGitHubUrl, repoName, progressBar) => {
  * @param cloneTask
  * @returns {Promise}
  */
-const clone = (services, task = cloneTask) => {
+const clone = (serviceRepoDetails, task = cloneTask) => {
   process.stdout.write(`Cloning repos...${newline}`)
 
-  const gitHubRepoInfo = getGitHubDetails(services)
   const progressBar = new Progress(':percent [:bar] (:current/:total)', {
-    total: gitHubRepoInfo.length,
+    total: serviceRepoDetails.length,
     clear: true
   })
-  const githubInfoParentArray = chunkArray(gitHubRepoInfo, numberOfCPUs * 4)
+  const serviceRepoDetailsParentArray = chunkArray(serviceRepoDetails, numberOfCPUs * 4)
 
   return co(function * () {
-    for (let i = 0; i < githubInfoParentArray.length; i++) {
-      yield githubInfoParentArray[i].map((details) => {
-        const url = details.url
-        const whichGitHub = details.name === 'github-com' ? 'public' : 'enterprise'
+    for (let i = 0; i < serviceRepoDetailsParentArray.length; i++) {
+      yield serviceRepoDetailsParentArray[i].map((serviceRepoDetail) => {
+        const url = serviceRepoDetail.url
+        const whichGitHub = serviceRepoDetail.name === 'github-com' ? 'public' : 'enterprise'
         const repoName = `${url.split('/').pop()}-${whichGitHub}`
         const sshGitHubUrl = toSshGitHubUrl(url)
 

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -7,6 +7,7 @@ import toSshGitHubUrl from './utils/toSshGitHubUrl'
 import chunkArray from './utils/chunkArray'
 
 const numberOfCPUs = cpus().length
+const spawnProcessPerCPU = 4
 
 /**
  *
@@ -45,7 +46,7 @@ const clone = (serviceRepoDetails, task = cloneTask) => {
     total: serviceRepoDetails.length,
     clear: true
   })
-  const serviceRepoDetailsParentArray = chunkArray(serviceRepoDetails, numberOfCPUs * 4)
+  const serviceRepoDetailsParentArray = chunkArray(serviceRepoDetails, numberOfCPUs * spawnProcessPerCPU)
 
   return co(function * () {
     for (let i = 0; i < serviceRepoDetailsParentArray.length; i++) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -5,16 +5,15 @@ import ServiceResults from './streams/ServiceResults'
 import ConsoleLogger from './streams/ConsoleLogger'
 import JSONLogger from './streams/JSONLogger'
 
-const createServiceResults = new ServiceResults({objectMode: true})
 const consoleLogger = new ConsoleLogger({objectMode: true})
 const jsonLogger = new JSONLogger({objectMode: true})
 
 /**
  * Search html markup using grep
- * @param {searchOptions}
- * @returns {Promise}
+ * @param gitHubRepoUrlMap
+ * @param searchOptions
  */
-const searchMarkup = (searchOptions) => {
+const searchMarkup = (serviceRepoUrls, searchOptions) => {
   let { fileExtensions } = searchOptions
   process.stdout.write(`Searching files...${fileExtensions}${newline}`)
 
@@ -23,6 +22,7 @@ const searchMarkup = (searchOptions) => {
     : fileExtensions
 
   // forward slash is made windows compatible inside glob https://www.npmjs.com/package/glob#windows
+  const createServiceResults = new ServiceResults({objectMode: true}, serviceRepoUrls)
   const findFiles = new FindFiles({objectMode: true}, `target/**/*.${fileExtensions}`)
   const match = new Match({objectMode: true}, searchOptions.searchString)
 

--- a/lib/streams/ServiceResults.js
+++ b/lib/streams/ServiceResults.js
@@ -9,6 +9,7 @@ import {sep as pathSeparator} from 'path'
   "github": "",
   "count": 1,
   "files": [{
+    url: "",
     path: "",
     line: "",
     match: ""
@@ -16,8 +17,9 @@ import {sep as pathSeparator} from 'path'
  }
  */
 class ServiceResults extends Transform {
-  constructor (options) {
+  constructor (options, serviceRepoUrls) {
     super(options)
+    this.serviceRepoUrls = serviceRepoUrls
     this.createServiceResultsObj()
   }
 
@@ -30,6 +32,15 @@ class ServiceResults extends Transform {
     }
   }
 
+  buildMatchUrl (whichGithub, repoName, filePath, lineNumber) {
+    return [
+      this.serviceRepoUrls[`${repoName}-${whichGithub}`],
+      '/blob/master',
+      filePath,
+      `#L${lineNumber}`
+    ].join('')
+  }
+
   _transform (matchDetail, encoding, done) {
     // filePath (a result from glob) has forward slashes for all platforms https://www.npmjs.com/package/glob#windows
     const [, folder, ...filePathParts] = matchDetail.filePath.split('/')
@@ -37,6 +48,7 @@ class ServiceResults extends Transform {
     const repoNameParts = folder.split('-')
     const whichGithub = repoNameParts.splice((repoNameParts.length - 1), 1)[0]
     const repoName = repoNameParts.join('-')
+    const url = this.buildMatchUrl(whichGithub, repoName, filePath, matchDetail.lineNumber)
 
     if (this.serviceResults.name && this.serviceResults.name !== repoName) {
       this.push(this.serviceResults)
@@ -47,6 +59,7 @@ class ServiceResults extends Transform {
     this.serviceResults.github = whichGithub
     this.serviceResults.count++
     this.serviceResults.files.push({
+      url: url,
       path: filePath,
       line: matchDetail.lineNumber,
       match: matchDetail.match.trim()

--- a/lib/utils/serviceRepoDetails.js
+++ b/lib/utils/serviceRepoDetails.js
@@ -1,0 +1,40 @@
+/**
+ * get an array containing all Service GitHub details
+ * @param services
+ * @returns {Array[Object{name, displayName, url}]}
+ */
+const getGitHubDetails = services => {
+  return services
+    .map(service => service.githubUrls)
+    .reduce((prev, curr) => prev.concat(curr))
+}
+
+/**
+ * Build an object containing all the repository github urls referenced by the repo name as a key <repoName-whichGitHub>
+ * @param gitHubDetails
+ * @param gitRepoUrls
+ */
+const getGitHubUrls = (gitHubDetails) => {
+  const gitHubRepoUrls = {}
+
+  gitHubDetails.forEach((githubDetail) => {
+    const whichGitHub = githubDetail.name === 'github-com' ? 'public' : 'enterprise'
+    const repoName = githubDetail.url.replace(/\/$/, '').split('/').slice(-1)
+
+    gitHubRepoUrls[`${repoName}-${whichGitHub}`] = githubDetail.url
+  })
+
+  return gitHubRepoUrls
+}
+
+const buildServiceRepoDetails = (frontendServices) => {
+  const gitHubDetails = getGitHubDetails(frontendServices)
+  const gitHubUrls = getGitHubUrls(gitHubDetails)
+
+  return {
+    details: gitHubDetails,
+    urls: gitHubUrls
+  }
+}
+
+export default buildServiceRepoDetails

--- a/test/ServiceResults.test.js
+++ b/test/ServiceResults.test.js
@@ -3,7 +3,12 @@ import ServiceResults from './../lib/streams/ServiceResults'
 import {PassThrough} from 'stream'
 
 const passThrough = new PassThrough({objectMode: true})
-const serviceResults = new ServiceResults({objectMode: true})
+const gitHubRepoUrls = {
+  'service-name-other-enterprise': 'https://example.private.com/org/service-name-other',
+  'service-name-public': 'https://example.open.com/org/service-name'
+}
+
+const serviceResults = new ServiceResults({objectMode: true}, gitHubRepoUrls)
 const matchDetailInputs = [
   {
     filePath: 'target/service-name-public/example/file/path/file.html',
@@ -21,12 +26,12 @@ const matchDetailInputs = [
     match: 'another example match'
   },
   {
-    filePath: 'target/service-name-other-public/example/file/path/file-other.html',
+    filePath: 'target/service-name-other-enterprise/example/file/path/file-other.html',
     lineNumber: 1,
     match: 'other match'
   },
   {
-    filePath: 'target/service-name-other-public/example/file/path/file-other1.html',
+    filePath: 'target/service-name-other-enterprise/example/file/path/file-other1.html',
     lineNumber: 3,
     match: 'another other match'
   }
@@ -39,16 +44,19 @@ const expectedServiceResults = [
     count: 3,
     files: [
       {
+        'url': 'https://example.open.com/org/service-name/blob/master/example/file/path/file.html#L19',
         'path': '/example/file/path/file.html',
         'line': 19,
         'match': 'example match'
       },
       {
+        'url': 'https://example.open.com/org/service-name/blob/master/example/file/path/file1.html#L34',
         'path': '/example/file/path/file1.html',
         'line': 34,
         'match': 'other example match'
       },
       {
+        'url': 'https://example.open.com/org/service-name/blob/master/example/file/path/file2.html#L101',
         'path': '/example/file/path/file2.html',
         'line': 101,
         'match': 'another example match'
@@ -57,15 +65,17 @@ const expectedServiceResults = [
   },
   {
     name: 'service-name-other',
-    github: 'public',
+    github: 'enterprise',
     count: 2,
     files: [
       {
+        'url': 'https://example.private.com/org/service-name-other/blob/master/example/file/path/file-other.html#L1',
         'path': '/example/file/path/file-other.html',
         'line': 1,
         'match': 'other match'
       },
       {
+        'url': 'https://example.private.com/org/service-name-other/blob/master/example/file/path/file-other1.html#L3',
         'path': '/example/file/path/file-other1.html',
         'line': 3,
         'match': 'another other match'
@@ -77,7 +87,7 @@ const expectedServiceResults = [
 test('service results created from lined input should be provided to consumer', async t => {
   let count = 0
 
-  matchDetailInputs.forEach(matchDetail => passThrough.write(matchDetail))
+  matchDetailInputs.forEach((matchDetail) => passThrough.write(matchDetail))
   passThrough.end()
 
   await passThrough

--- a/test/clone.test.js
+++ b/test/clone.test.js
@@ -4,25 +4,16 @@ import clone from './../lib/clone'
 
 const mockServices = [
   {
-    name: 'testData',
-    githubUrls: [
-      {
-        name: 'github-com',
-        displayName: 'GitHub.com',
-        url: 'https://github.com/test-url'
-      }
-    ]
+    name: 'github-com',
+    displayName: 'GitHub.com',
+    url: 'https://github.com/test-url'
   },
   {
-    name: 'testDataOther',
-    githubUrls: [
-      {
-        name: 'github-com',
-        displayName: 'GitHub.com',
-        url: 'https://github.com/test-url-other'
-      }
-    ]
+    name: 'github-com',
+    displayName: 'GitHub.com',
+    url: 'https://github.com/test-url-other'
   }
+
 ]
 
 test.before(t => sinon.stub(process.stdout, 'write'))

--- a/test/serviceRepoDetails.test.js
+++ b/test/serviceRepoDetails.test.js
@@ -1,0 +1,59 @@
+import test from 'ava'
+import getServiceRepoDetails from './../lib/utils/serviceRepoDetails'
+
+const mockServices = [
+  {
+    name: 'example-repo-name',
+    description: 'example description',
+    createdAt: 1425991873000,
+    lastActive: 1489744039000,
+    teamNames: [
+      'example team'
+    ],
+    repoType: 'example repo type',
+    githubUrls: [
+      {
+        name: 'github-com',
+        displayName: 'GitHub.com',
+        url: 'https://github.com/example-repo-name-url'
+      }
+    ]
+  },
+  {
+    name: 'example-repo-name-other',
+    description: 'example description other',
+    createdAt: 1425991873004,
+    lastActive: 1489744039030,
+    teamNames: [
+      'example team other'
+    ],
+    repoType: 'example repo type other',
+    githubUrls: [
+      {
+        name: 'github-other',
+        displayName: 'Enterprise',
+        url: 'https://github.com/example-repo-name-url-other'
+      }
+    ]
+  }
+]
+const expectedServiceRepoDetails = [
+  {
+    name: 'github-com',
+    displayName: 'GitHub.com',
+    url: 'https://github.com/example-repo-name-url'
+  },
+  {
+    name: 'github-other',
+    displayName: 'Enterprise',
+    url: 'https://github.com/example-repo-name-url-other'
+  }
+]
+
+test('.gitHubDetails() should return the expected output', async t => {
+  const serviceRepoDetails = getServiceRepoDetails(mockServices)
+
+  t.deepEqual(serviceRepoDetails.details, expectedServiceRepoDetails)
+  t.is(serviceRepoDetails.urls['example-repo-name-url-public'], 'https://github.com/example-repo-name-url')
+  t.is(serviceRepoDetails.urls['example-repo-name-url-other-enterprise'], 'https://github.com/example-repo-name-url-other')
+})


### PR DESCRIPTION
## Problem
You have to construct the match url out of all the parts if you wish to have a look at the match in a GitHub location in a browser. 

## Solution
We have all the parts to create the url, this work brings them together and adds them to the `results.json` file. This work fixes #28 

### Of Note

I have done the work to provide a `serviceRepoDetails` object consisting of:
- *details* - an array containing all Service GitHub details
- *urls* - an object containing all the repository github urls referenced by the repo name as a key <repoName-whichGitHub>

This work has been done upfront in [finder.js](https://github.com/hmrc/component-finder/compare/add-url-to-results.json?expand=1#diff-1189c0ac45a591b2d09bd3a6d0bd0eb2R31) inside of a `then` to be able to pass this information along the promise chain. Therefore this It has changed a number of module interfaces used further down the promise chain, for example in [clone](https://github.com/hmrc/component-finder/compare/add-url-to-results.json?expand=1#diff-9ec301707dc23dc3a292ba164bd39a82R38) and the [ServiceResults.js](https://github.com/hmrc/component-finder/compare/add-url-to-results.json?expand=1#diff-6c64069efcaa11d92d818279a27822d2R20) stream.

Its worth merging https://github.com/hmrc/component-finder/pull/31 into master before this work is merged as there have been a few changes around the generator implementation, changes that this work also touches.

Tests updated where relevant
 
## Screenshot
![screen shot 2017-03-17 at 15 38 12](https://cloud.githubusercontent.com/assets/2305016/24052057/0f85391c-0b2c-11e7-8d7a-13b60bad31d0.png)


