### PR TITLE
Add logging verbosity flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ e.g. `node index.js -f jade searchstring`
 
 e.g. `node index.js -f "js, java" searchstring`
 
+#### Increase logging verbosity 
+
+Logging is available via the `logging` utility module. By default the logging level is set to `0` this will display all `logger.log()` method calls. If you wish to increase the logging level to see both `logger.log()` and `logging.debug()` calls you can do so by passing the `-v` flag.
+
+e.g. `node index.js -v`
+e.g. `node index.js --verbose`
+
 ### Results
 
 Results appear in the console like this...

--- a/finder.js
+++ b/finder.js
@@ -5,6 +5,7 @@ import search from './lib/search'
 import serviceCatalogue from './lib/serviceCatalogue'
 import isFrontendService from './lib/utils/isFrontendService'
 import getServiceRepoDetails from './lib/utils/serviceRepoDetails'
+import {setupLogger, logger} from './lib/utils/logging'
 
 try {
   var config = require('./config.json')
@@ -21,9 +22,16 @@ const args = yargs
     type: 'string',
     describe: 'The file extension(s) of the files to search'
   })
+  .option('v', {
+    alias: 'verbose',
+    type: 'count',
+    describe: 'Increase logging verbosity'
+  })
   .demandCommand(1)
   .help()
   .argv
+
+setupLogger(args.verbose)
 
 serviceCatalogue.getProjects(config.api)
   .then((services) => services.filter(service => isFrontendService(service.name, config.whitelist)))
@@ -33,4 +41,4 @@ serviceCatalogue.getProjects(config.api)
     return clone(serviceRepoDetails.details)
       .then(() => search(serviceRepoDetails.urls, {fileExtensions: args.file, searchString: args._}))
   })
-  .catch((err) => console.error(err))
+  .catch((err) => logger.log(err))

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -5,6 +5,7 @@ import {EOL as newline, cpus} from 'os'
 import {spawn} from 'child_process'
 import toSshGitHubUrl from './utils/toSshGitHubUrl'
 import chunkArray from './utils/chunkArray'
+import {logger} from './utils/logging'
 
 const numberOfCPUs = cpus().length
 const spawnProcessPerCPU = 4
@@ -22,9 +23,11 @@ const cloneTask = (sshGitHubUrl, repoName, progressBar) => {
     const clonePath = path.resolve(__dirname, '..', 'target', repoName)
     const gitClone = spawn('git', ['clone', '--depth', '1', sshGitHubUrl, clonePath])
 
-    gitClone.on('error', err => reject(`Error cloning ${repoName}: ${err}`))
+    gitClone.stderr.on('data', (data) => logger.debug(data.toString()))
 
-    gitClone.on('close', code => {
+    gitClone.on('error', (err) => reject(`Error cloning ${repoName}: ${err}`))
+
+    gitClone.on('close', (code) => {
       progressBar.tick()
       resolve()
     })

--- a/lib/serviceCatalogue.js
+++ b/lib/serviceCatalogue.js
@@ -1,6 +1,7 @@
 import co from 'co'
 import https from 'https'
 import {EOL as newline} from 'os'
+import {logger} from './utils/logging'
 
 const errMsg = (apiDomain) => `
 Could not connect to ${apiDomain}.
@@ -56,7 +57,7 @@ const getServices = (apiConfig, path) => {
         }
       })
     }).on('error', (err) => {
-      console.error(err)
+      logger.log(err)
       reject(errMsg(apiConfig.host))
     })
   })

--- a/lib/streams/ConsoleLogger.js
+++ b/lib/streams/ConsoleLogger.js
@@ -1,6 +1,7 @@
 import {Transform} from 'stream'
 import {EOL as newline} from 'os'
 import formatter from './../utils/formatter'
+import {logger} from './../utils/logging'
 
 /**
  * Log service results to the console
@@ -18,7 +19,7 @@ class ConsoleLogger extends Transform {
     this.data.projects++
     this.data.occurrences += results.count
 
-    console.log(formatter(results))
+    logger.log(formatter(results))
     this.push(results)
 
     done()

--- a/lib/utils/logging.js
+++ b/lib/utils/logging.js
@@ -1,0 +1,36 @@
+let logger
+
+const consoleOutput = (value) => {
+  if (value instanceof Error) {
+    console.error(value)
+  } else {
+    console.log(value)
+  }
+}
+
+class Logger {
+  constructor (loggingLevel) {
+    this.loggingLevel = loggingLevel
+  }
+
+  debug (value) {
+    if (this.loggingLevel === 1) {
+      consoleOutput(value)
+    }
+  }
+
+  log (value) {
+    consoleOutput(value)
+  }
+}
+
+const setupLogger = (loggingLevel) => {
+  if (logger instanceof Logger !== true) {
+    logger = new Logger(loggingLevel)
+  }
+}
+
+export {
+  setupLogger,
+  logger
+}

--- a/test/ConsoleLogger.test.js
+++ b/test/ConsoleLogger.test.js
@@ -2,6 +2,7 @@ import test from 'ava'
 import sinon from 'sinon'
 import ConsoleLogger from './../lib/streams/ConsoleLogger'
 import {PassThrough} from 'stream'
+import {setupLogger} from './../lib/utils/logging'
 
 const serviceResults = [
   {
@@ -26,6 +27,7 @@ const serviceResults = [
 ]
 
 test.before(t => {
+  setupLogger(0)
   sinon.stub(console, 'log')
   sinon.stub(process.stdout, 'write')
 })

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,0 +1,73 @@
+import test from 'ava'
+import sinon from 'sinon'
+
+const loggingModulePath = './../lib/utils/logging'
+const spyConsoleLog = sinon.spy(console, 'log')
+const spyConsoleError = sinon.spy(console, 'error')
+let loggingModule
+
+test.beforeEach(t => {
+  loggingModule = require(loggingModulePath)
+})
+
+test.afterEach(t => {
+  // Remove module from require cache to be able to reset loggingLevel
+  delete require.cache[require.resolve(loggingModulePath)]
+
+  spyConsoleLog.reset()
+  spyConsoleError.reset()
+})
+
+test('logger.log() should call console.log() as expected', t => {
+  const logMessage = 'example log message'
+
+  loggingModule.setupLogger(0)
+  loggingModule.logger.log(logMessage)
+
+  t.is(loggingModule.logger.loggingLevel, 0)
+  t.true(spyConsoleLog.calledOnce)
+  t.is(spyConsoleLog.getCall(0).args[0], logMessage)
+})
+
+test('logger.log() should call console.error() as expected', t => {
+  const logErrorMessage = 'example log error message'
+
+  loggingModule.setupLogger(0)
+  loggingModule.logger.log(Error(logErrorMessage))
+
+  t.is(loggingModule.logger.loggingLevel, 0)
+  t.true(spyConsoleError.calledOnce)
+  t.is(spyConsoleError.getCall(0).args[0].message, logErrorMessage)
+})
+
+test('logger.debug() should call console.log() as expected', t => {
+  const debugLogMessage = 'example debug log message'
+
+  loggingModule.setupLogger(1)
+  loggingModule.logger.debug(debugLogMessage)
+
+  t.is(loggingModule.logger.loggingLevel, 1)
+  t.true(spyConsoleLog.calledOnce)
+  t.is(spyConsoleLog.getCall(0).args[0], debugLogMessage)
+})
+
+test('logger.debug() should call console.error() as expected', t => {
+  const debugLogMessage = 'example debug log message'
+
+  loggingModule.setupLogger(1)
+  loggingModule.logger.debug(Error(debugLogMessage))
+
+  t.is(loggingModule.logger.loggingLevel, 1)
+  t.true(spyConsoleError.calledOnce)
+  t.is(spyConsoleError.getCall(0).args[0].message, debugLogMessage)
+})
+
+test('logger.debug() should not be called when loggingLevel is 0', t => {
+  const debugLogMessage = 'example debug log message'
+
+  loggingModule.setupLogger(0)
+  loggingModule.logger.debug(debugLogMessage)
+
+  t.is(loggingModule.logger.loggingLevel, 0)
+  t.true(spyConsoleError.notCalled)
+})

--- a/test/serviceCatalogue.test.js
+++ b/test/serviceCatalogue.test.js
@@ -2,6 +2,7 @@ import test from 'ava'
 import nock from 'nock'
 import sinon from 'sinon'
 import serviceCatalogue from './../lib/serviceCatalogue'
+import {setupLogger} from './../lib/utils/logging'
 
 const apiConfig = {
   'protocol': 'http',
@@ -56,7 +57,10 @@ Could not connect to ${apiDomain}.
 Please make sure you're config details are correct
 and you are connected to a VPN if you need to be.`
 
-test.before(t => sinon.stub(process.stdout, 'write'))
+test.before(t => {
+  sinon.stub(process.stdout, 'write')
+  setupLogger(0)
+})
 
 test.after(t => process.stdout.write.restore())
 


### PR DESCRIPTION
This work adds the ability to pass in a `-v` flag to increase verbosity of logging.

Logging is available via the `logging` utility module. By default the logging level is set to `0` this will display all `logger.log()` method calls. 
If you wish to increase the logging level to see both `logger.log()` and `logging.debug()` calls you can do so by passing the `-v` flag.
